### PR TITLE
Fixed version of restify

### DIFF
--- a/Node/exercise1-EchoBot.md
+++ b/Node/exercise1-EchoBot.md
@@ -27,7 +27,8 @@ The Bot Builder SDK for Node.js is a powerful, easy-to-use framework that provid
 1. Next, install the [Bot Builder SDK](https://dev.botframework.com), [Restify](http://restify.com/) and [Dotenv](https://github.com/motdotla/dotenv) modules by running the following npm commands:
 
     ```
-    npm install --save botbuilder restify dotenv
+    npm install --save botbuilder dotenv
+    npm install --save restify@4.1.1
     ```
 
     Bot Builder, part of Bot Framework, is used to create the bot, while Restify is used to serve the web application which will host your bot. Please notice that the Bot Builder SDK is independent of the Web framework you use. This hands-on lab uses Restify, but you can use others like Express or Koa. Dotenv is used to easily maintain all configuration settings in a separated file.

--- a/Node/exercise1-EchoBot/package.json
+++ b/Node/exercise1-EchoBot/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "botbuilder": "^3.8.4",
     "dotenv": "^4.0.0",
-    "restify": "^4.3.0"
+    "restify": "4.1.1"
   },
   "devDependencies": {
     "nodemon": "^1.11.0"


### PR DESCRIPTION
TypeError: restify.bodyParser is not a function (in current version of restify 6.0.1)
Error appeared in exercise 2 task 4 
 // Setup body parser and tickets api
server.use(restify.bodyParser()); 