### PR TITLE
Fixed  help dialog to work with LUIS recognizer

### DIFF
--- a/Node/exercise3-LuisDialog/app.js
+++ b/Node/exercise3-LuisDialog/app.js
@@ -41,7 +41,7 @@ bot.dialog('Help',
     (session, args, next) => {
         session.endDialog(`I'm the help desk bot and I can help you create a ticket.\n` +
             `You can tell me things like _I need to reset my password_ or _I cannot print_.`);
-        builder.Prompts.text(session, 'First, please briefly describe your problem to me.');
+        session.send('First, please briefly describe your problem to me.');
     }
 ).triggerAction({
     matches: 'Help'


### PR DESCRIPTION
builder.Prompts.text adds new entry to context.dialogStack().length. You need to use session.send instead